### PR TITLE
don't overwrite original error message

### DIFF
--- a/baiji/pod/asset_cache.py
+++ b/baiji/pod/asset_cache.py
@@ -102,8 +102,8 @@ class CacheFile(object):
     def download(self, verbose=True):
         try:
             s3.cp(self.remote, self.local, force=True, progress=verbose, validate=True)
-        except s3.KeyNotFound:
-            raise s3.KeyNotFound('{} not found on s3'.format(self.remote))
+        except s3.KeyNotFound as e:
+            raise s3.KeyNotFound('{0} not found on s3. Reason: {1}'.format(self.remote, str(e)))
         self.update_timestamp()
 
     @property

--- a/baiji/pod/asset_cache.py
+++ b/baiji/pod/asset_cache.py
@@ -103,7 +103,7 @@ class CacheFile(object):
         try:
             s3.cp(self.remote, self.local, force=True, progress=verbose, validate=True)
         except s3.KeyNotFound as e:
-            raise s3.KeyNotFound('{0} not found on s3. Reason: {1}'.format(self.remote, str(e)))
+            raise e
         self.update_timestamp()
 
     @property


### PR DESCRIPTION
I don't think we should overwrite the original error message from `baiji` because `KeyNotFound` there come with various error messages and is helpful.