### PR TITLE
Relax version of cached_property

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 baiji>=2.2.9
-cached_property>=1.3.0,<1.4
+cached_property>=1.3.0
 env_flag>=1.0.0,<2.0.0
 harrison>=1.0.0,<2.0.0
 semantic-version>=2.4.2,<2.5.0


### PR DESCRIPTION
This avoids some [install issues seen in CI](https://circleci.com/gh/metabolize/lace/5):

```
Exception:
Traceback (most recent call last):
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_internal/basecommand.py", line 141, in main
    status = self.run(options, args)
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_internal/commands/install.py", line 299, in run
    resolver.resolve(requirement_set)
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_internal/resolve.py", line 102, in resolve
    self._resolve_one(requirement_set, req)
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_internal/resolve.py", line 256, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_internal/resolve.py", line 193, in _get_abstract_dist_for
    req, self.require_hashes, self.use_user_site, self.finder,
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_internal/operations/prepare.py", line 329, in prepare_editable_requirement
    req.check_if_exists(use_user_site)
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_internal/req/req_install.py", line 494, in check_if_exists
    self.req.name
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 468, in get_distribution
    dist = get_provider(dist)
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 344, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 888, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 779, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
ContextualVersionConflict: (cached-property 1.5.1 (/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages), Requirement.parse('cached-property<1.4,>=1.3.0'), set(['baiji-pod']))
```